### PR TITLE
Change the original function arity with decorators

### DIFF
--- a/doc/decorators.asciidoc
+++ b/doc/decorators.asciidoc
@@ -262,6 +262,73 @@ function main = |args| {
 }
 ----
 
+A last thing (but not the least), the function returned by the decorator can
+have a different arity than the original one:
+
+[source,golo]
+----
+function curry = |f| -> |a| -> |b| -> f(a, b)
+
+@curry
+function add = |a,b| -> a + b
+
+function main = |args| {
+  add(12)(30)
+}
+----
+
+The `@curry` decorator transform the `add` function that takes two arguments, in a function
+that takes only one arguments and return a function that takes the second argument and finally
+return the result of the addition.
+
+NOTE: A decorator is applied only if the decorated function is called from Golo
+code. For example if you try to call a decorated Golo function from Java code
+it will be not the decorated function that will be called but the original one.
+
+TIP: It is possible to create decorator and decorated functions in pure Java:
+
+[source,java]
+----
+package decorators;
+
+import gololang.DecoratedBy;
+import gololang.FunctionReference;
+
+public class Decorators {
+
+  public static Object decorator(Object original) {
+    FunctionReference reference = (FunctionReference) original;
+    // do some transformations
+    System.out.println("decorator!");
+    return reference;
+  }
+
+  @DecoratedBy("decorator")
+  public static int add(int a, int b) {
+    return a + b;
+  }
+
+}
+----
+
+Let's call this from Golo:
+
+[source,golo]
+----
+import decorators.Decorators
+
+function main = |args| {
+  println(add(10,32))
+}
+----
+
+will print:
+
+----
+decorator!
+42
+----
+
 
 Let's now illustrate with some use cases and examples, with a presentation of
 some decorators of the standard module

--- a/doc/decorators.asciidoc
+++ b/doc/decorators.asciidoc
@@ -277,13 +277,13 @@ function main = |args| {
 }
 ----
 
-The `@curry` decorator transform the `add` function that takes two arguments, in a function
-that takes only one arguments and return a function that takes the second argument and finally
-return the result of the addition.
+The `@curry` decorator transform the `add` function that takes two arguments,
+into a function that takes only one argument and returns a function that takes
+the second argument and finally return the result of the addition.
 
 NOTE: A decorator is applied only if the decorated function is called from Golo
 code. For example if you try to call a decorated Golo function from Java code
-it will be not the decorated function that will be called but the original one.
+it will not be the decorated function that will be called but the original one.
 
 TIP: It is possible to create decorator and decorated functions in pure Java:
 
@@ -291,7 +291,7 @@ TIP: It is possible to create decorator and decorated functions in pure Java:
 ----
 package decorators;
 
-import gololang.DecoratedBy;
+import gololang.annotations.DecoratedBy;
 import gololang.FunctionReference;
 
 public class Decorators {

--- a/src/main/java/fr/insalyon/citi/golo/compiler/JavaBytecodeGenerationGoloIrVisitor.java
+++ b/src/main/java/fr/insalyon/citi/golo/compiler/JavaBytecodeGenerationGoloIrVisitor.java
@@ -307,7 +307,7 @@ class JavaBytecodeGenerationGoloIrVisitor implements GoloIrVisitor {
         signature,
         null, null);
     if (function.isDecorated()) {
-      AnnotationVisitor annotation = methodVisitor.visitAnnotation("Lgololang/DecoratedBy;", true);
+      AnnotationVisitor annotation = methodVisitor.visitAnnotation("Lgololang/annotations/DecoratedBy;", true);
       annotation.visit("value", function.getDecoratorRef());
       annotation.visitEnd();
     }

--- a/src/main/java/fr/insalyon/citi/golo/compiler/JavaBytecodeGenerationGoloIrVisitor.java
+++ b/src/main/java/fr/insalyon/citi/golo/compiler/JavaBytecodeGenerationGoloIrVisitor.java
@@ -298,7 +298,7 @@ class JavaBytecodeGenerationGoloIrVisitor implements GoloIrVisitor {
     } else {
       signature = goloFunctionSignature(function.getArity());
     }
-    if (function.isSynthetic()) {
+    if (function.isSynthetic() || function.isDecorator()) {
       accessFlags = accessFlags | ACC_SYNTHETIC;
     }
     methodVisitor = classWriter.visitMethod(
@@ -306,6 +306,11 @@ class JavaBytecodeGenerationGoloIrVisitor implements GoloIrVisitor {
         function.getName(),
         signature,
         null, null);
+    if (function.isDecorated()) {
+      AnnotationVisitor annotation = methodVisitor.visitAnnotation("Lgololang/DecoratedBy;", true);
+      annotation.visit("value", function.getDecoratorRef());
+      annotation.visitEnd();
+    }
     for(String parameter: function.getParameterNames()) {
       methodVisitor.visitParameter(parameter, ACC_FINAL);
     }

--- a/src/main/java/fr/insalyon/citi/golo/compiler/JavaBytecodeGenerationGoloIrVisitor.java
+++ b/src/main/java/fr/insalyon/citi/golo/compiler/JavaBytecodeGenerationGoloIrVisitor.java
@@ -424,7 +424,7 @@ class JavaBytecodeGenerationGoloIrVisitor implements GoloIrVisitor {
           "gololang#Predefined#fun",
           "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
           FUNCTION_INVOCATION_HANDLE,
-          (Object) 0);
+          (Object) 1); // this specific call can be banged
       return;
     }
     if (value instanceof Double) {

--- a/src/main/java/fr/insalyon/citi/golo/compiler/ParseTreeToGoloIrVisitor.java
+++ b/src/main/java/fr/insalyon/citi/golo/compiler/ParseTreeToGoloIrVisitor.java
@@ -235,7 +235,6 @@ class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
     }
     context.objectStack.push(function);
     if (!function.getDecorators().isEmpty()) {
-      function.setDecorated(true);
       function.setDecoratorRef("__$$_" + function.getName() + "_decorator_" + context.nextDecoratorId++);
     }
     node.childrenAccept(this, data);

--- a/src/main/java/fr/insalyon/citi/golo/compiler/ir/GoloFunction.java
+++ b/src/main/java/fr/insalyon/citi/golo/compiler/ir/GoloFunction.java
@@ -41,7 +41,6 @@ public final class GoloFunction extends ExpressionStatement {
   private boolean varargs;
   private Block block;
   private boolean synthetic = false;
-  private boolean decorated = false;
   private boolean decorator = false;
   private String syntheticSelfName = null;
   private String decoratorRef = null;
@@ -102,11 +101,7 @@ public final class GoloFunction extends ExpressionStatement {
   }
 
   public boolean isDecorated() {
-    return decorated;
-  }
-
-  public void setDecorated(boolean decorated) {
-    this.decorated = decorated;
+    return !decorators.isEmpty();
   }
 
   public boolean isDecorator() {

--- a/src/main/java/fr/insalyon/citi/golo/compiler/ir/GoloFunction.java
+++ b/src/main/java/fr/insalyon/citi/golo/compiler/ir/GoloFunction.java
@@ -41,7 +41,10 @@ public final class GoloFunction extends ExpressionStatement {
   private boolean varargs;
   private Block block;
   private boolean synthetic = false;
+  private boolean decorated = false;
+  private boolean decorator = false;
   private String syntheticSelfName = null;
+  private String decoratorRef = null;
   private LinkedList<Decorator> decorators = new LinkedList<>();
 
   public GoloFunction(String name, Visibility visibility, Scope scope) {
@@ -98,12 +101,36 @@ public final class GoloFunction extends ExpressionStatement {
     this.synthetic = synthetic;
   }
 
+  public boolean isDecorated() {
+    return decorated;
+  }
+
+  public void setDecorated(boolean decorated) {
+    this.decorated = decorated;
+  }
+
+  public boolean isDecorator() {
+    return decorator;
+  }
+
+  public void setDecorator(boolean decorator) {
+    this.decorator = decorator;
+  }
+
   public String getSyntheticSelfName() {
     return syntheticSelfName;
   }
 
   public void setSyntheticSelfName(String syntheticSelfName) {
     this.syntheticSelfName = syntheticSelfName;
+  }
+
+  public String getDecoratorRef() {
+    return decoratorRef;
+  }
+
+  public void setDecoratorRef(String decoratorRef) {
+    this.decoratorRef = decoratorRef;
   }
 
   public Visibility getVisibility() {

--- a/src/main/java/fr/insalyon/citi/golo/compiler/parser/ASTFunctionDeclaration.java
+++ b/src/main/java/fr/insalyon/citi/golo/compiler/parser/ASTFunctionDeclaration.java
@@ -21,6 +21,7 @@ public class ASTFunctionDeclaration extends GoloASTNode implements NamedNode {
   private String name;
   private boolean local = false;
   private boolean augmentation = false;
+  private boolean decorator = false;
 
   public ASTFunctionDeclaration(int i) {
     super(i);
@@ -56,11 +57,20 @@ public class ASTFunctionDeclaration extends GoloASTNode implements NamedNode {
     this.augmentation = augmentation;
   }
 
+  public boolean isDecorator() {
+    return decorator;
+  }
+
+  public void setDecorator(boolean decorator) {
+    this.decorator = decorator;
+  }
+
   @Override
   public String toString() {
     return "ASTFunctionDeclaration{" +
         "name='" + name + '\'' +
         ", local=" + local +
+        ", decorator=" + decorator +
         ", augmentation=" + augmentation +
         '}';
   }

--- a/src/main/java/fr/insalyon/citi/golo/runtime/DecoratorsHelper.java
+++ b/src/main/java/fr/insalyon/citi/golo/runtime/DecoratorsHelper.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2015 Institut National des Sciences Appliquées de Lyon (INSA-Lyon).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.insalyon.citi.golo.runtime;
+
+import gololang.DecoratedBy;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import static java.lang.invoke.MethodType.methodType;
+import java.lang.reflect.Method;
+
+public final class DecoratorsHelper {
+
+  private static final MethodHandle FUNCCTION_REFEFERENCE_TO_METHODHANDLE;
+  private static final MethodHandle INVOKE_WITH_ARGUMENTS;
+
+  static {
+    try {
+      MethodHandles.Lookup lookup = MethodHandles.lookup();
+      FUNCCTION_REFEFERENCE_TO_METHODHANDLE = lookup.findStatic(
+          DecoratorsHelper.class,
+          "functionReferenceToMethodHandle",
+          MethodType.methodType(Object.class, Object.class));
+      INVOKE_WITH_ARGUMENTS = lookup.findVirtual(
+          MethodHandle.class,
+          "invokeWithArguments",
+          MethodType.methodType(Object.class, Object[].class));
+    } catch (NoSuchMethodException | IllegalAccessException e) {
+      throw new Error("Could not bootstrap the required method handles", e);
+    }
+  }
+
+  private DecoratorsHelper() {
+  }
+
+  public static boolean isMethodDecorated(Method method) {
+    return method.isAnnotationPresent(DecoratedBy.class);
+  }
+
+  public static Method getDecoratorMethod(Method decorated) {
+    try {
+      return decorated.getDeclaringClass().getDeclaredMethod(decorated.getAnnotation(DecoratedBy.class).value(), Object.class);
+    } catch (NoSuchMethodException | SecurityException ex) {
+      throw new IllegalStateException("Unable to get the decorator for a method marked as decorated", ex);
+    }
+  }
+
+  private static Object functionReferenceToMethodHandle(Object retValue) {
+    return ((gololang.FunctionReference) retValue).handle();
+  }
+
+  public static MethodHandle getDecoratedMethodHandle(MethodHandles.Lookup caller, Method originalMethod, int arity) {
+    try {
+      Method decoratorMethod = getDecoratorMethod(originalMethod);
+      MethodHandle decorator = caller.unreflect(decoratorMethod);
+      decorator = MethodHandles.filterReturnValue(decorator, FUNCCTION_REFEFERENCE_TO_METHODHANDLE);
+      MethodHandle original = caller.unreflect(originalMethod);
+      decorator = decorator.bindTo(new gololang.FunctionReference(original)).asType(methodType(MethodHandle.class));
+      if (arity < 0) {
+        MethodHandle combined = MethodHandles.foldArguments(INVOKE_WITH_ARGUMENTS, decorator);
+        return combined.asVarargsCollector(Object[].class);
+      } else {
+        MethodHandle invoker = MethodHandles.invoker(MethodType.genericMethodType(arity));
+        MethodHandle combined = MethodHandles.foldArguments(invoker, decorator);
+        return combined;
+      }
+    } catch (IllegalAccessException ex) {
+      throw new IllegalStateException("Unable to get the decorator for a method marked as decorated", ex);
+    }
+  }
+
+  public static MethodHandle getDecoratedMethodHandle(Method originalMethod, int arity) {
+    return getDecoratedMethodHandle(MethodHandles.lookup(), originalMethod, arity);
+  }
+
+  public static MethodHandle getDecoratedMethodHandle(Method originalMethod) {
+    return getDecoratedMethodHandle(MethodHandles.lookup(), originalMethod, -1);
+  }
+}

--- a/src/main/java/fr/insalyon/citi/golo/runtime/DecoratorsHelper.java
+++ b/src/main/java/fr/insalyon/citi/golo/runtime/DecoratorsHelper.java
@@ -15,7 +15,7 @@
  */
 package fr.insalyon.citi.golo.runtime;
 
-import gololang.DecoratedBy;
+import gololang.annotations.DecoratedBy;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;

--- a/src/main/java/gololang/DecoratedBy.java
+++ b/src/main/java/gololang/DecoratedBy.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 Institut National des Sciences Appliquées de Lyon (INSA-Lyon).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gololang;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * <code>@DecoratedBy</code> is used to define the reference to the decorator on a decorated function.
+ *
+ * Mainly used for internal stuff, this annotation can be useful to create decorated function in Java.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Documented
+public @interface DecoratedBy {
+  /**
+   * This is the reference to the decorator function.
+   *
+   * @return the reference to the decorator function.
+   */
+  String value();
+}

--- a/src/main/java/gololang/Predefined.java
+++ b/src/main/java/gololang/Predefined.java
@@ -34,7 +34,8 @@ import java.util.*;
 
 import static java.lang.invoke.MethodHandles.dropArguments;
 import static java.lang.reflect.Modifier.isStatic;
-
+import static fr.insalyon.citi.golo.runtime.DecoratorsHelper.isMethodDecorated;
+import static fr.insalyon.citi.golo.runtime.DecoratorsHelper.getDecoratedMethodHandle;
 /**
  * <code>Predefined</code> provides the module of predefined functions in Golo. The provided module is imported by
  * default.
@@ -400,7 +401,7 @@ public final class Predefined {
     LinkedHashSet<Method> validCandidates = new LinkedHashSet<>();
     for (Method method : candidates) {
       if (method.getName().equals(functionName) && Modifier.isStatic(method.getModifiers())) {
-        if ((functionArity < 0) || (method.getParameterTypes().length == functionArity)) {
+        if (isMethodDecorated(method) || (functionArity < 0) || (method.getParameterTypes().length == functionArity)) {
           validCandidates.add(method);
         }
       }
@@ -408,6 +409,13 @@ public final class Predefined {
     if (validCandidates.size() == 1) {
       targetMethod = validCandidates.iterator().next();
       targetMethod.setAccessible(true);
+      if(isMethodDecorated(targetMethod)) {
+        if (functionArity < 0) {
+          return new FunctionReference(getDecoratedMethodHandle(targetMethod));
+        } else {
+          return new FunctionReference(getDecoratedMethodHandle(targetMethod, functionArity));
+        }
+      }
       return new FunctionReference(MethodHandles.publicLookup().unreflect(targetMethod));
     }
     if (validCandidates.size() > 1) {

--- a/src/main/java/gololang/annotations/DecoratedBy.java
+++ b/src/main/java/gololang/annotations/DecoratedBy.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package gololang;
+package gololang.annotations;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;

--- a/src/main/java/gololang/annotations/package-info.java
+++ b/src/main/java/gololang/annotations/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2015 Institut National des Sciences Appliquées de Lyon (INSA-Lyon)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides useful annotations to deal with Golo into Java code.
+ */
+package gololang.annotations;

--- a/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
@@ -1651,34 +1651,44 @@ public class CompileAndRunTest {
     assertThat(result, instanceOf(String.class));
     assertThat(result, is((Object) "12"));
 
-    decorated = moduleClass.getMethod("test_generic_decorator_simple", Object.class, Object.class);
-    result = decorated.invoke(null, "4", "2");
+    decorated = moduleClass.getMethod("test_generic_decorator_simple");
+    result = decorated.invoke(null);
     assertThat(result, instanceOf(String.class));
     assertThat(result, is((Object) "(42)"));
 
-    decorated = moduleClass.getMethod("test_generic_decorator_varargs", Object[].class);
-    result = decorated.invoke(null, (Object) new String[]{});
+    decorated = moduleClass.getMethod("test_generic_decorator_varargs0");
+    result = decorated.invoke(null);
     assertThat(result, instanceOf(String.class));
     assertThat(result, is((Object) "()"));
 
-    decorated = moduleClass.getMethod("test_generic_decorator_varargs", Object[].class);
-    result = decorated.invoke(null, (Object) new String[]{"4", "2"});
+    decorated = moduleClass.getMethod("test_generic_decorator_varargs1");
+    result = decorated.invoke(null);
+    assertThat(result, instanceOf(String.class));
+    assertThat(result, is((Object) "(4)"));
+
+    decorated = moduleClass.getMethod("test_generic_decorator_varargs2");
+    result = decorated.invoke(null);
     assertThat(result, instanceOf(String.class));
     assertThat(result, is((Object) "(42)"));
 
-    decorated = moduleClass.getMethod("test_generic_decorator_varargs", Object[].class);
-    result = decorated.invoke(null, (Object) new String[]{"4"});
+    decorated = moduleClass.getMethod("test_generic_decorator_varargs2_from_reference");
+    result = decorated.invoke(null);
     assertThat(result, instanceOf(String.class));
-    assertThat(result, is((Object) "(4)"));
+    assertThat(result, is((Object) "(42)"));
+
+    decorated = moduleClass.getMethod("test_generic_decorator_varargs2_from_enclosed_reference");
+    result = decorated.invoke(null);
+    assertThat(result, instanceOf(String.class));
+    assertThat(result, is((Object) "(42)"));
 
     decorated = moduleClass.getMethod("test_generic_decorator_parameterless");
     result = decorated.invoke(null);
     assertThat(result, instanceOf(String.class));
     assertThat(result, is((Object) "(test)"));
 
-    decorated = moduleClass.getMethod("test_check_args", Object.class);
+    decorated = moduleClass.getMethod("test_check_args");
     try {
-      decorated.invoke(null, "42");
+      decorated.invoke(null);
       fail("An exception should have been thrown");
     } catch (InvocationTargetException invocationTargetException) {
       Throwable cause = invocationTargetException.getCause();
@@ -1686,6 +1696,21 @@ public class CompileAndRunTest {
       AssertionError exception = (AssertionError) cause;
       assertThat(exception.getMessage(), is("arg0 must be a class java.lang.Integer"));
     }
+
+    decorated = moduleClass.getMethod("test_struct_decorated_augmentation");
+    result = decorated.invoke(null);
+    assertThat(result, instanceOf(String.class));
+    assertThat(result, is((Object) "struct Point{x=40, y=20}"));
+
+    decorated = moduleClass.getMethod("test_struct_decorated_named_augmentation");
+    result = decorated.invoke(null);
+    assertThat(result, instanceOf(String.class));
+    assertThat(result, is((Object) "struct Point{x=40, y=20}"));
+
+    decorated = moduleClass.getMethod("test_curryfied_function");
+    result = decorated.invoke(null);
+    assertThat(result, instanceOf(Integer.class));
+    assertThat(result, is((Object) 42));
   }
 
   @Test
@@ -1693,18 +1718,18 @@ public class CompileAndRunTest {
 
     Class<?> moduleClass = compileAndLoadGoloModule(SRC, "bang.golo");
 
-    Method banged = moduleClass.getMethod("func_test",Object.class);
-    Object result = banged.invoke(null,42);
+    Method banged = moduleClass.getMethod("func_test", Object.class);
+    Object result = banged.invoke(null, 42);
     assertThat(result, equalTo(banged.invoke(null, 1337)));
 
-    banged = moduleClass.getMethod("null_test",Object.class);
+    banged = moduleClass.getMethod("null_test", Object.class);
     result = banged.invoke(null, (Object) null);
-    assertThat(result,equalTo(null));
+    assertThat(result, equalTo(null));
     assertThat(result, equalTo(banged.invoke(null, 1337)));
 
-    banged = moduleClass.getMethod("reference_test",Object.class);
+    banged = moduleClass.getMethod("reference_test", Object.class);
     result = banged.invoke(null, 42);
-    assertThat(result, equalTo(banged.invoke(null,1337)));
+    assertThat(result, equalTo(banged.invoke(null, 1337)));
 
     banged = moduleClass.getMethod("singleton");
     result = banged.invoke(null);
@@ -1714,24 +1739,24 @@ public class CompileAndRunTest {
     result = banged.invoke(null, 10, 12, 20);
     assertThat(result, equalTo(banged.invoke(null, 42, 42, 42)));
 
-    banged = moduleClass.getMethod("decorated");
+    banged = moduleClass.getMethod("test_decorated");
     result = banged.invoke(null);
     assertThat(result, equalTo(banged.invoke(null)));
     assertThat(result, not((Object) 42));
 
     Method set_param = moduleClass.getMethod("set_decorator_parameter", Object.class);
-    set_param.invoke(null,(Object)1337);
+    set_param.invoke(null, (Object) 1337);
 
-    banged = moduleClass.getMethod("parametrized_decorated");
+    banged = moduleClass.getMethod("test_parametrized_decorated");
     result = banged.invoke(null);
     assertThat(result, equalTo(banged.invoke(null)));
-    assertThat(result, not((Object)42));
+    assertThat(result, not((Object) 42));
 
     set_param.invoke(null, (Object) 42);
 
     result = banged.invoke(null);
     assertThat(result, equalTo(banged.invoke(null)));
-    assertThat(result, not((Object)42));
+    assertThat(result, not((Object) 42));
 
   }
 

--- a/src/test/resources/for-execution/bang.golo
+++ b/src/test/resources/for-execution/bang.golo
@@ -11,7 +11,7 @@ function identity = |a| -> a
 function adder = |a| -> |b| -> |c| -> a + b + c
 
 function decorator = |func| {
-  let marker =java.lang.Object()
+  let marker = java.lang.Object()
   let wrapper = -> marker:hashCode()
   return wrapper
 }
@@ -40,3 +40,7 @@ function decorated = -> 42
 
 @!parametrized_decorator(decorator_parameter)
 function parametrized_decorated =  -> 42
+
+function test_parametrized_decorated = -> parametrized_decorated()
+
+function test_decorated = -> decorated()


### PR DESCRIPTION
It is not currently possible to change the
the arity of a decorated function.
( see https://gist.github.com/yloiseau/d669c0e30023bf5b5bbc )

Originaly the function `foo`:

```golo
module curry

function curry = |f| -> |a| -> |b| -> f(a, b)

@curry
function foo = |a,b| -> a + b

```

is converted to :

```golo
module curry

function curry = |f| -> |a| -> |b| -> f(a, b)

function foo = |a,b| -> ^curry( |a, b| -> a + b )(a, b)
```

The trick tranforms the original function in a
variable arity function like this :

```golo
module curry

function curry = |f| -> |a| -> |b| -> f(a, b)

function foo = |args...| -> ^curry( |a, b| -> a + b ): invokeWithArguments(args)
```