### PR TITLE
Create promise with thread

### DIFF
--- a/src/main/golo/async.golo
+++ b/src/main/golo/async.golo
@@ -75,6 +75,15 @@ augment gololang.concurrent.async.Promise {
     closure(|data| -> this: set(data), |err| -> this: fail(err))
     return this: future()
   }
+  ----
+  You can define a promise which runs "stuff" inside a Thread
+  ----
+  function initializeWithThread = |this, closure| {
+    Thread({
+      this: initialize(closure)
+    }): start()
+    return this: future()
+  }
 }
 
 ----


### PR DESCRIPTION
    # define promise
    let do_it =  -> promise(): initializeWithThread(|resolve, reject| {
       # the code runs inside a thread
      resolve(42)
    })

    # run promise
    do_it(): onSet(|result| { # if success
      println(result)
    }): onFail(|err| { # if failed
      println(err: getMessage())
    })