### PR TITLE
add 'invalid' token

### DIFF
--- a/src/main/java/fr/insalyon/citi/golo/compiler/utils/NamingUtils.java
+++ b/src/main/java/fr/insalyon/citi/golo/compiler/utils/NamingUtils.java
@@ -19,7 +19,10 @@ package fr.insalyon.citi.golo.compiler.utils;
 public class NamingUtils {
 
   public static int packageClassSeparatorIndex(String moduleName) {
-    return moduleName.lastIndexOf('.');
+    if (moduleName != null) {
+      return moduleName.lastIndexOf('.');
+    }
+    return -1;
   }
 
   public static String extractTargetJavaPackage(String moduleName) {

--- a/src/main/jjtree/Golo.jjt
+++ b/src/main/jjtree/Golo.jjt
@@ -403,6 +403,13 @@ TOKEN :
   < DOCUMENTATION : "----" (" " | "\t")* ("\n" | "\r" | "\r\n") > : DEFAULT
 }
 
+// Everything else
+<DEFAULT,ESCAPED,WithinDocumentation,WithinMultiString>
+TOKEN :
+{
+  < INVALID: ~[" ","\t","\r","\f","`", ".", ":", "{", "}", "|", "(", ")", "=", ",", "]", "-"] > : DEFAULT
+}
+
 // ............................................................................................. //
 
 TOKEN_MGR_DECLS :


### PR DESCRIPTION
add an 'invalid' token to avoid TokenMgrError when " or - characters are typed in netbeans. Check not null parameter to avoid NullPointerException when user add an import statement
