### PR TITLE
Makes Tuple object comparable.

### DIFF
--- a/src/main/java/gololang/Tuple.java
+++ b/src/main/java/gololang/Tuple.java
@@ -142,7 +142,9 @@ public final class Tuple implements Iterable<Object>, HeadTail<Object>, Comparab
    */
   @Override
   public int compareTo(Tuple other) {
-    if (this.equals(other)) {return 0;}
+    if (this.equals(other)) {
+      return 0;
+    }
     if (this.size() != other.size()) {
       throw new IllegalArgumentException(String.format(
             "%s and %s can't be compared since of different size", this, other));

--- a/src/main/java/gololang/Tuple.java
+++ b/src/main/java/gololang/Tuple.java
@@ -31,7 +31,7 @@ import java.util.Iterator;
  * let t2 = tuple[1, 2, 3]
  * </pre>
  */
-public final class Tuple implements Iterable<Object>, HeadTail<Object> {
+public final class Tuple implements Iterable<Object>, HeadTail<Object>, Comparable<Tuple> {
 
   private final Object[] data;
 
@@ -125,6 +125,36 @@ public final class Tuple implements Iterable<Object>, HeadTail<Object> {
 
     Tuple tuple = (Tuple) o;
     return Arrays.equals(data, tuple.data);
+  }
+
+  /**
+   * Compares this tuple with the specified tuple for order.
+   * <p>Returns a negative integer, zero, or a positive integer as this tuple is less than, equal to, or greater than the specified tuple.
+   * <p>Two tuples are compared using the lexicographical (dictionary) order, that is:
+   * {@code [1, 2] < [1, 3]} and {@code [2, 5] < [3, 1]}.
+   * <p> Two tuples are comparable if they have the same size and their elements are pairwise comparable.
+   *
+   * @param other the tuple to be compared.
+   * @return a negative integer, zero, or a positive integer as this tuple is less than, equal to, or greater than the specified tuple.
+   * @throws NullPointerException if the specified tuple is null
+   * @throws ClassCastException  if the type of the elements in the specified tuple prevent them from being compared to this tuple elements.
+   * @throws IllegalArgumentException if the specified tuple has a different size than this tuple.
+   */
+  @Override
+  public int compareTo(Tuple other) {
+    if (this.equals(other)) {return 0;}
+    if (this.size() != other.size()) {
+      throw new IllegalArgumentException(String.format(
+            "%s and %s can't be compared since of different size", this, other));
+    }
+    for (int i = 0; i < size(); i++) {
+      if (!this.get(i).equals(other.get(i))) {
+        @SuppressWarnings("unchecked")
+        Comparable<Object> current = (Comparable<Object>) this.get(i);
+        return current.compareTo(other.get(i));
+      }
+    }
+    return 0;
   }
 
   @Override

--- a/src/test/java/gololang/TupleTest.java
+++ b/src/test/java/gololang/TupleTest.java
@@ -23,6 +23,9 @@ import java.util.Iterator;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.comparesEqualTo;
 import static org.hamcrest.Matchers.nullValue;
 
 public class TupleTest {
@@ -88,4 +91,54 @@ public class TupleTest {
     assertThat(tuple, not(new Tuple(1, 2, "3")));
     assertThat(tuple, not(new Tuple()));
   }
+
+  @Test
+  public void tuples_comparison() {
+    Tuple base = new Tuple(1, 2, 3);
+    Tuple equal = new Tuple(1, 2, 3);
+    Tuple smaller = new Tuple(1, 2, 1);
+    Tuple evenSmaller = new Tuple(0, 5, 6);
+    Tuple greater = new Tuple(1, 2, 5);
+    Tuple evenGreater = new Tuple(2, 1, 0);
+
+    assertThat(base, comparesEqualTo(base));
+    assertThat(base, comparesEqualTo(equal));
+    assertThat(base, is(lessThan(greater)));
+    assertThat(base, is(lessThan(evenGreater)));
+    assertThat(base, is(greaterThan(smaller)));
+    assertThat(base, is(greaterThan(evenSmaller)));
+  }
+
+  @Test
+  public void heterogeneous_tuples_comparison() {
+    Tuple base = new Tuple(1, "a", 3.1);
+    Tuple equal = new Tuple(1, "a", 3.1);
+    Tuple smaller = new Tuple(1, "a", 2.5);
+    Tuple evenSmaller = new Tuple(0, "c", 6.9);
+    Tuple greater = new Tuple(1, "c", 2.0);
+    Tuple evenGreater = new Tuple(2, "a", 0.0);
+
+    assertThat(base, comparesEqualTo(base));
+    assertThat(base, comparesEqualTo(equal));
+    assertThat(base, is(lessThan(greater)));
+    assertThat(base, is(lessThan(evenGreater)));
+    assertThat(base, is(greaterThan(smaller)));
+    assertThat(base, is(greaterThan(evenSmaller)));
+  }
+
+  @Test(expectedExceptions = ClassCastException.class)
+  public void different_type_comparison() {
+    new Tuple(1, 2, 3).compareTo(new Tuple("a", "b", "c"));
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void different_size_comparison() {
+    new Tuple(1, 2, 3).compareTo(new Tuple(1, 2));
+  }
+
+  @Test(expectedExceptions = ClassCastException.class)
+  public void not_comparable_comparison() {
+    new Tuple(new Object()).compareTo(new Tuple(new Object()));
+  }
 }
+


### PR DESCRIPTION
`Tuple` now implements `Comparable<Tuple>`. The comparison is done
pairwise, using lexicographical order, such that `[1, 2] < [1, 3]`
and `["b", 5] < ["d", 1]`.