### PR TITLE
Fix Bug #219.

### DIFF
--- a/src/main/java/fr/insalyon/citi/golo/compiler/JavaBytecodeGenerationGoloIrVisitor.java
+++ b/src/main/java/fr/insalyon/citi/golo/compiler/JavaBytecodeGenerationGoloIrVisitor.java
@@ -358,7 +358,9 @@ class JavaBytecodeGenerationGoloIrVisitor implements GoloIrVisitor {
   }
 
   private boolean isMethodCall(BinaryOperation operation) {
-    return operation.getType() == METHOD_CALL || operation.getType() == ELVIS_METHOD_CALL;
+    return operation.getType() == METHOD_CALL
+            || operation.getType() == ELVIS_METHOD_CALL
+            || operation.getType() == ANON_CALL;
   }
 
   @Override

--- a/src/main/java/fr/insalyon/citi/golo/compiler/ParseTreeToGoloIrVisitor.java
+++ b/src/main/java/fr/insalyon/citi/golo/compiler/ParseTreeToGoloIrVisitor.java
@@ -440,15 +440,22 @@ class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
     }
     ExpressionStatement right = expressions.pop();
     ExpressionStatement left = expressions.pop();
-    OperatorType operator = operators.pop();
+    OperatorType operator = OperatorType.ANON_CALL;
+    if (!operators.isEmpty()) {
+      operator = operators.pop();
+    }
     BinaryOperation current = new BinaryOperation(operator, left, right);
+
     if (operator == ELVIS_METHOD_CALL) {
       MethodInvocation invocation = (MethodInvocation) right;
       invocation.setNullSafeGuarded(true);
     }
     while (!expressions.isEmpty()) {
       left = expressions.pop();
-      operator = operators.pop();
+      operator = OperatorType.ANON_CALL;
+      if (!operators.isEmpty()) {
+        operator = operators.pop();
+      }
       if (operator == ELVIS_METHOD_CALL) {
         MethodInvocation invocation = (MethodInvocation) current.getLeftExpression();
         invocation.setNullSafeGuarded(true);

--- a/src/main/java/fr/insalyon/citi/golo/runtime/OperatorType.java
+++ b/src/main/java/fr/insalyon/citi/golo/runtime/OperatorType.java
@@ -42,6 +42,7 @@ public enum OperatorType {
 
   ORIFNULL("orIfNull"),
 
+  ANON_CALL(""),
   METHOD_CALL(":"),
   ELVIS_METHOD_CALL("?:");
 

--- a/src/main/jjtree/Golo.jjt
+++ b/src/main/jjtree/Golo.jjt
@@ -1032,6 +1032,8 @@ void AssociativeExpression():
       {
         jjtThis.addOperator(token.image);
       }
+    |
+      AnonymousFunctionInvocation()
     )
   )*
   (LOOKAHEAD(1) BlankLine())?

--- a/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
@@ -160,6 +160,15 @@ public class CompileAndRunTest {
   }
 
   @Test
+  public void test_direct_anonymous_call() throws ClassNotFoundException, IOException, ParseException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    Class<?> moduleClass = compileAndLoadGoloModule(SRC, "direct-anon-call.golo");
+    for (String name : asList("with_invoke", "direct_call", "ident", "anon_ident", "currified")) {
+      Method meth = moduleClass.getMethod(name);
+      assertThat((int) meth.invoke(null), is(2));
+    }
+  }
+
+  @Test
   @SuppressWarnings("unchecked")
   public void test_variable_assignments() throws ClassNotFoundException, IOException, ParseException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
     Class<?> moduleClass = compileAndLoadGoloModule(SRC, "variable-assignments.golo");

--- a/src/test/resources/for-execution/direct-anon-call.golo
+++ b/src/test/resources/for-execution/direct-anon-call.golo
@@ -1,0 +1,30 @@
+module golotest.execution.AnonCall
+
+function with_invoke = {
+  return (|x| -> x + 1): invokeWithArguments(1)  
+}
+
+function direct_call = {
+  return (|x| -> x + 1)(1)  
+}
+
+function ident = {
+  let id = |x| -> x
+  return id(|x| -> x + 1)(1)
+}
+
+function anon_ident = {
+  return (|x| -> x)(|x| -> x + 1)(1)  
+}
+
+function currified = {
+  return (|x| -> |y| -> x + y)(1)(1)  
+}
+
+function main = |args| {
+  require(with_invoke() == 2, "err") 
+  require(direct_call() == 2, "err") 
+  require(ident() == 2, "err") 
+  require(anon_ident() == 2, "err")
+  require(currified() == 2, "err")
+}


### PR DESCRIPTION
As described in #219, it was impossible to directly call a anonymous function, as in
`(|x| -> x + 1)(1)`

This is fixed by allowing `AnonymousFunctionInvocation` in an
`AssociativeExpression` in the parser.

This change generates `BinaryOperation` with empty operator that must
thus be checked.