### PR TITLE
Print JVM version from command line 'version'

### DIFF
--- a/src/main/java/fr/insalyon/citi/golo/cli/Main.java
+++ b/src/main/java/fr/insalyon/citi/golo/cli/Main.java
@@ -428,7 +428,8 @@ public class Main {
 
   private static void version(VersionCommand options) {
     if (options.full) {
-      System.out.println(Metadata.VERSION + " (build " + Metadata.TIMESTAMP + ")");
+      System.out.println("Golo version: " + Metadata.VERSION + " (build " + Metadata.TIMESTAMP + ")");
+      System.out.println("JVM version: " + System.getProperty("java.version"));
     } else {
       System.out.println(Metadata.VERSION);
     }


### PR DESCRIPTION
With the command 'version' and the option '--full',
this print the actual golo full version and the JVM version.

For example :
```
Golo version : 2.1.0-SNAPSHOT (build 15-03-15-12:34)
JVM version: 1.8.0_31
```