### PR TITLE
Escape module name during project creation to avoid a compilation failure

### DIFF
--- a/src/main/java/fr/insalyon/citi/golo/cli/Main.java
+++ b/src/main/java/fr/insalyon/citi/golo/cli/Main.java
@@ -323,12 +323,16 @@ public class Main {
   private static void createMainGoloFile(File intoDir, String projectName) throws FileNotFoundException, UnsupportedEncodingException {
     File mainGoloFile = new File(intoDir, "main.golo");
     PrintWriter writer = new PrintWriter(mainGoloFile, "UTF-8");
-    writer.println("module " + projectName);
+    writer.println("module " + escapeModuleName(projectName));
     writer.println("");
     writer.println("function main = |args| {");
     writer.println("  println(\"Hello " + projectName + "!\")");
     writer.println("}");
     writer.close();
+  }
+
+  private static String escapeModuleName(String projectName) {
+    return projectName.replaceAll("\\W", ".");
   }
 
   private static void writeProjectFile(File intoDir, String projectName, String sourcePath, String fileName) throws IOException {

--- a/src/test/java/fr/insalyon/citi/golo/cli/MainTest.java
+++ b/src/test/java/fr/insalyon/citi/golo/cli/MainTest.java
@@ -47,13 +47,13 @@ public class MainTest {
 
   @Test
   public void golo_new_default_free_form_with_name() throws Throwable {
-    delete(new File("Foo"));
+    delete(new File("project-Golo"));
     try {
-      Main.main("new", "Foo");
-      assertFreeFormProjectStructure("Foo");
-      assertThat(readFile("Foo/main.golo"), containsString("module Foo"));
+      Main.main("new", "project-Golo");
+      assertFreeFormProjectStructure("project-Golo");
+      assertThat(readFile("project-Golo/main.golo"), containsString("module project.Golo"));
     } finally {
-      delete(new File("Foo"));
+      delete(new File("project-Golo"));
     }
   }
 
@@ -73,15 +73,45 @@ public class MainTest {
   }
 
   @Test
+  public void golo_new_maven_project_with_name() throws Throwable {
+    delete(new File("project-Golo"));
+    try {
+      Main.main("new", "--type", "maven", "project-Golo");
+      assertMavenProjectStructure("project-Golo");
+      assertThat(readFile("project-Golo/src/main/golo/main.golo"), containsString("module project.Golo"));
+      final String pomContent = readFile("project-Golo/pom.xml");
+      assertThat(pomContent, containsString("<artifactId>project-Golo</artifactId>"));
+      assertThat(pomContent, containsString("<mainClass>project-Golo</mainClass>"));
+    } finally {
+      delete(new File("project-Golo"));
+    }
+  }
+
+  @Test
   public void golo_new_gradle_project() throws Throwable {
     delete(new File("Golo"));
     try {
       Main.main("new", "--type", "gradle");
       assertGradleProjectStructure("Golo");
+      assertThat(readFile("Golo/src/main/golo/main.golo"), containsString("module Golo"));
       final String buildContent = readFile("Golo/build.gradle");
       assertThat(buildContent, containsString("mainModule = 'Golo'"));
     } finally {
       delete(new File("Golo"));
+    }
+  }
+
+  @Test
+  public void golo_new_gradle_project_with_name() throws Throwable {
+    delete(new File("project-Golo"));
+    try {
+      Main.main("new", "--type", "gradle", "project-Golo");
+      assertGradleProjectStructure("project-Golo");
+      assertThat(readFile("project-Golo/src/main/golo/main.golo"), containsString("module project.Golo"));
+      final String buildContent = readFile("project-Golo/build.gradle");
+      assertThat(buildContent, containsString("mainModule = 'project-Golo'"));
+    } finally {
+      delete(new File("project-Golo"));
     }
   }
 


### PR DESCRIPTION
During a project creation with 'new' command line,
if a project name contains a non-word caracter,
they are escape into the dot caracter to avoid a compilation failure.