### PR TITLE
Fix tests and doc of anonymous function call.

### DIFF
--- a/doc/closures.asciidoc
+++ b/doc/closures.asciidoc
@@ -305,23 +305,3 @@ Golo supports a nicer syntax if you don't need intermediate references:
 println(f(1)(2)(3)())
 ----
 
-[IMPORTANT]
-====
-This syntax only works following a function or method invocation, not on expressions. This means
-that:
-
-[source,golo]
-----
-foo: bar()("baz")
-----
-
-is valid, while:
-
-[source,golo]
-----
-(foo: bar())("baz")
-----
-
-is not. Let us say that "It is not a bug, it is a feature".
-====
-

--- a/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
@@ -162,7 +162,7 @@ public class CompileAndRunTest {
   @Test
   public void test_direct_anonymous_call() throws ClassNotFoundException, IOException, ParseException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
     Class<?> moduleClass = compileAndLoadGoloModule(SRC, "direct-anon-call.golo");
-    for (String name : asList("with_invoke", "direct_call", "ident", "anon_ident", "currified")) {
+    for (String name : asList("with_invoke", "direct_call", "ident", "anon_ident", "currified", "struct_field", "struct_method", "dynamic")) {
       Method meth = moduleClass.getMethod(name);
       assertThat((int) meth.invoke(null), is(2));
     }

--- a/src/test/resources/for-execution/direct-anon-call.golo
+++ b/src/test/resources/for-execution/direct-anon-call.golo
@@ -1,5 +1,10 @@
 module golotest.execution.AnonCall
 
+struct MyStruct = { func }
+augment MyStruct {
+  function meth = |this| -> |a| -> a + 1
+}
+
 function with_invoke = {
   return (|x| -> x + 1): invokeWithArguments(1)  
 }
@@ -21,10 +26,28 @@ function currified = {
   return (|x| -> |y| -> x + y)(1)(1)  
 }
 
+function struct_field = {
+  let s = MyStruct(|a| -> a + 1)
+  return (s: func())(1)
+}
+
+function struct_method = {
+  let s = MyStruct(1)
+  return (s: meth())(1)
+}
+
+function dynamic = {
+  let o = DynamicObject(): define("meth", |this| -> |a| -> a + 1)
+  return (o: meth())(1)
+}
+
 function main = |args| {
   require(with_invoke() == 2, "err") 
   require(direct_call() == 2, "err") 
   require(ident() == 2, "err") 
   require(anon_ident() == 2, "err")
   require(currified() == 2, "err")
+  require(struct_field() == 2, "err")
+  require(struct_method() == 2, "err")
+  require(dynamic() == 2, "err")
 }


### PR DESCRIPTION
This PR fixes some oversight in PR #247

- adds a few tests on direct anonymous function call when the function
  is returned by a method invocation
- change the doc accordingly, since now the warning in the
  “calling functions that return functions” section is no longer valid