### PR TITLE
Check andThen function parameter arity

### DIFF
--- a/src/main/java/gololang/FunctionReference.java
+++ b/src/main/java/gololang/FunctionReference.java
@@ -139,6 +139,9 @@ public class FunctionReference {
    * @return a composed function.
    */
   public FunctionReference andThen(FunctionReference fun) {
+    if (fun.type().parameterCount() != 1) {
+      throw new IllegalArgumentException("andThen requires a function with exactly 1 parameter");
+    }
     return new FunctionReference(filterReturnValue(this.handle, fun.handle));
   }
 

--- a/src/test/java/gololang/FunctionReferenceTest.java
+++ b/src/test/java/gololang/FunctionReferenceTest.java
@@ -93,4 +93,15 @@ public class FunctionReferenceTest {
     assertThat(fun.handle().invoke("1", "2", "3"), is("123"));
     assertThat(fun.spread("1", new Object[]{"2", "3"}), is("123"));
   }
+
+  @Test
+  public void andThen() throws Throwable {
+    FunctionReference fun = new FunctionReference(ping).andThen(new FunctionReference(ping));
+    assertThat(fun.invoke("Plop"), is("Plop"));
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*1 parameter.*")
+  public void andThen_bad_arity() throws Throwable {
+    new FunctionReference(ping).andThen(new FunctionReference(collectN));
+  }
 }


### PR DESCRIPTION
Checks that the function argument takes exactly 1 parameter.
Interestingly, the composition of method handles with filterReturnValue and mismatching
types is possible, and provokes a SIGSEGV of the JVM at runtime.

Fix for #262

Signed-off-by: Julien Ponge <julien.ponge@insa-lyon.fr>