### PR TITLE
Refactoring the augmented join method

### DIFF
--- a/src/main/golo/standard-augmentations.golo
+++ b/src/main/golo/standard-augmentations.golo
@@ -50,6 +50,25 @@ local function _closureWithIndexArgument = |target| -> match {
     target
 }
 
+local function _join = |this, separator| {
+  let size = this: size()
+  case {
+    when size == 0 {
+      return ""
+    }
+    when size == 1 {
+      return this: get(0): toString()
+    }
+    otherwise {
+      let buffer = java.lang.StringBuilder(this: get(0): toString())
+      for (var i = 1, i < size, i = i + 1) {
+        buffer: append(separator): append(this: get(i): toString())
+      }
+      return buffer: toString()
+    }
+  }
+}
+
 # ............................................................................................... #
 
 ----
@@ -423,18 +442,7 @@ augment java.util.List {
 
   The returned string is `""` when the list is empty.
   ----
-  function join = |this, separator| {
-    var buffer = java.lang.StringBuilder("")
-    if not (this: isEmpty()) {
-      buffer: append(this: head())
-      let tail = this: tail()
-      if not (tail: isEmpty()) {
-        buffer: append(separator)
-        buffer: append(tail: join(separator))
-      }
-    }
-    return buffer: toString()
-  }
+  function join = |this, separator| -> _join(this, separator)
 
   ----
   Reverse the elements of the list and returns the list.
@@ -829,24 +837,7 @@ augment gololang.Tuple {
   ----
   Joins the elements of a tuple into a string and using a separator.
   ----
-  function join = |this, separator| {
-    let size = this: size()
-    case {
-      when size == 0 {
-        return ""
-      }
-      when size == 1 {
-        return this: get(0): toString()
-      }
-      otherwise {
-        let buffer = java.lang.StringBuilder(this: get(0): toString())
-        for (var i = 1, i < size, i = i + 1) {
-          buffer: append(separator): append(this: get(i): toString())
-        }
-        return buffer: toString()
-      }
-    }
-  }
+  function join = |this, separator| -> _join(this, separator)
 }
 
 # ............................................................................................... #

--- a/src/test/java/gololang/StandardAugmentationsTest.java
+++ b/src/test/java/gololang/StandardAugmentationsTest.java
@@ -95,6 +95,16 @@ public class StandardAugmentationsTest {
   }
 
   @Test
+  public void lists_join() throws Throwable {
+    Method lists_join = moduleClass.getMethod("lists_join");
+    Object result = lists_join.invoke(null);
+    assertThat(result, instanceOf(String.class));
+    assertThat((String) result, is("a-3-false-[foo]"));
+  }
+
+
+
+  @Test
   @SuppressWarnings("unchecked")
   public void list_reverse() throws Throwable {
     Method list_reverse = moduleClass.getMethod("list_reverse");
@@ -534,6 +544,15 @@ public class StandardAugmentationsTest {
     Object result = tuple_not_exists.invoke(null);
     assertThat((Boolean) result, is(false));
   }
+
+  @Test
+  public void tuple_join() throws Throwable {
+    Method tuple_join = moduleClass.getMethod("tuple_join");
+    Object result = tuple_join.invoke(null);
+    assertThat(result, instanceOf(String.class));
+    assertThat((String) result, is("a-3-false-[foo]"));
+  }
+
 
   @Test
   public void vector_count() throws Throwable {

--- a/src/test/resources/for-test/bootstrapped-standard-augmentations.golo
+++ b/src/test/resources/for-test/bootstrapped-standard-augmentations.golo
@@ -36,6 +36,8 @@ function lists_each = {
   return int: get()
 }
 
+function lists_join = -> list["a", 3, false, ArrayList(): append("foo")]: join("-")
+
 function list_reverse = {
   return list_data(): reverse()
 }
@@ -254,6 +256,8 @@ function tuple_exists = {
 function tuple_not_exists = {
  return tuple_data(): exists(|item| -> item >= 6)
 }
+
+function tuple_join = -> ["a", 3, false, ArrayList(): append("foo")]: join("-")
 
 # ............................................................................................... #
 


### PR DESCRIPTION
Since `Tuple` and `List` have both a `get` method the `join` algo can be extracted and mutualized. 
This is a quick, naive and dirty workaround fo #268 .