### PR TITLE
Allows `fun` to retrieve non-static methods.

### DIFF
--- a/doc/closures.asciidoc
+++ b/doc/closures.asciidoc
@@ -269,6 +269,22 @@ function call_local_fun = {
 }
 ----
 
+Note that you can in the same way get a reference to a Java static method. For
+instance:
+
+[source,golo]
+----
+list["Foo", null, 42]: filter(^java.util.Objects::nonNull)
+----
+
+You can also get a reference to a non-static method. In this case, the function
+will accept an instance of the class as first argument, as in:
+
+[source,golo]
+----
+list["Foo", "Bar", "Hello", "Goodbye"]: map(^String::length)
+----
+
 === Binding and composing ===
 
 You can bind a function first argument using the `bindTo(value)` method. If you need to bind an

--- a/src/main/java/gololang/FunctionReference.java
+++ b/src/main/java/gololang/FunctionReference.java
@@ -189,6 +189,9 @@ public class FunctionReference {
    */
   public FunctionReference bindAt(String parameterName, Object value) {
     int position = -1;
+    if (this.parameterNames == null) {
+      throw new RuntimeException("Can't bind on parameter name, " + this.toString() + " has none");
+    }
     for (int i = 0; i < this.parameterNames.length; i++) {
       if (this.parameterNames[i].equals(parameterName)) {
         position = i;
@@ -233,8 +236,8 @@ public class FunctionReference {
         .invoke(arguments);
   }
 
-
   private String[] dropParameterNames(int from, int size) {
+    if (this.parameterNames == null) { return null; }
     String[] filtered = new String[this.parameterNames.length - size];
     System.arraycopy(parameterNames, 0, filtered, 0, from);
     System.arraycopy(parameterNames, from + size, filtered, from, this.parameterNames.length - size - from);

--- a/src/main/java/gololang/Predefined.java
+++ b/src/main/java/gololang/Predefined.java
@@ -400,7 +400,7 @@ public final class Predefined {
     candidates.addAll(Arrays.asList(moduleClass.getMethods()));
     LinkedHashSet<Method> validCandidates = new LinkedHashSet<>();
     for (Method method : candidates) {
-      if (method.getName().equals(functionName) && Modifier.isStatic(method.getModifiers())) {
+      if (method.getName().equals(functionName)) {
         if (isMethodDecorated(method) || (functionArity < 0) || (method.getParameterTypes().length == functionArity)) {
           validCandidates.add(method);
         }

--- a/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
@@ -862,6 +862,15 @@ public class CompileAndRunTest {
       assertThat(cause, instanceOf(AmbiguousFunctionReferenceException.class));
     }
 
+    Method call_java_func_literal = moduleClass.getMethod("call_java_func_literal");
+    assertThat((Tuple) call_java_func_literal.invoke(null), is(equalTo(new Tuple(true, false))));
+
+    Method call_java_method_literal = moduleClass.getMethod("call_java_method_literal");
+    assertThat((List) call_java_method_literal.invoke(null), is(equalTo(asList(5, 7, 3, 3))));
+    
+    Method call_java_method_literal_arity2 = moduleClass.getMethod("call_java_method_literal_arity2");
+    assertThat((List) call_java_method_literal_arity2.invoke(null), is(equalTo(asList("Hello", "Foo"))));
+    
     Method nested_closures = moduleClass.getMethod("nested_closures");
     result = nested_closures.invoke(null);
     assertThat(result, notNullValue());

--- a/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
@@ -869,7 +869,7 @@ public class CompileAndRunTest {
     assertThat((List) call_java_method_literal.invoke(null), is(equalTo(asList(5, 7, 3, 3))));
     
     Method call_java_method_literal_arity2 = moduleClass.getMethod("call_java_method_literal_arity2");
-    assertThat((List) call_java_method_literal_arity2.invoke(null), is(equalTo(asList("Hello", "Foo"))));
+    assertThat((List) call_java_method_literal_arity2.invoke(null), is(equalTo(asList(true, false, true, false))));
     
     Method nested_closures = moduleClass.getMethod("nested_closures");
     result = nested_closures.invoke(null);

--- a/src/test/resources/for-execution/closures.golo
+++ b/src/test/resources/for-execution/closures.golo
@@ -114,12 +114,12 @@ function call_java_func_literal = {
 
 function call_java_method_literal_arity2 = {
   let f = ^String::endsWith: bindAt(1, "o")
-  return list["Hello", "Goodbye", "Foo", "Bar"]: filter(f)
+  return list[f("Hello"), f("Goodbye"), f("Foo"), f("Bar")]
 }
 
 function call_java_method_literal = {
   let f = ^String::length
-  return list["Hello", "Goodbye", "Foo", "Bar"]: map(f)
+  return list[f("Hello"), f("Goodbye"), f("Foo"), f("Bar")]
 }
 
 function nested_closures = {

--- a/src/test/resources/for-execution/closures.golo
+++ b/src/test/resources/for-execution/closures.golo
@@ -107,6 +107,21 @@ function call_local_overloaded_fun_full_literal = {
   return f(1, 2)
 }
 
+function call_java_func_literal = {
+  let f = ^java.util.Objects::isNull
+  return [ f(null), f("42") ]
+}
+
+function call_java_method_literal_arity2 = {
+  let f = ^String::endsWith: bindAt(1, "o")
+  return list["Hello", "Goodbye", "Foo", "Bar"]: filter(f)
+}
+
+function call_java_method_literal = {
+  let f = ^String::length
+  return list["Hello", "Goodbye", "Foo", "Bar"]: map(f)
+}
+
 function nested_closures = {
   let s = "plop"
   let f1 = |x| -> x


### PR DESCRIPTION
This allows `gololang.Predefined::fun` to retrieve non-static methods,
and so to access unbound methods. It is now possible to write:
```golo
list["Foo", "Bar", "Hello", "Goodbye"]
  : filter(^String::endsWith: bindAt(1, "o"))
```
instead of
```golo
list["Foo", "Bar", "Hello", "Goodbye"]
  : filter(|s| -> s: endsWith("o"))
```
or
```golo
list["Foo", "Bar", "Hello", "Goodbye"]
  : map(^String::length)
```

Also fixes a NPE on named parameters in `FunctionReference`.