### PR TITLE
Fix bug #273.

### DIFF
--- a/src/main/java/fr/insalyon/citi/golo/runtime/FunctionCallSupport.java
+++ b/src/main/java/fr/insalyon/citi/golo/runtime/FunctionCallSupport.java
@@ -97,7 +97,7 @@ public final class FunctionCallSupport {
             caller,
             method.getName(),
             methodType(type),
-            handle.type(),
+            lambdaType,
             handle,
             lambdaType);
         return callSite.dynamicInvoker().invoke();

--- a/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
@@ -1773,7 +1773,7 @@ public class CompileAndRunTest {
   public void lambda8_interop() throws Throwable {
     Class<?> moduleClass = compileAndLoadGoloModule(SRC, "java8-lambda.golo");
     Method sum_it = moduleClass.getMethod("sum_it");
-    assertThat(sum_it.invoke(null), is((Object) 150));
+    assertThat(sum_it.invoke(null), is((Object) 60));
   }
 
   @Test

--- a/src/test/resources/for-execution/java8-lambda.golo
+++ b/src/test/resources/for-execution/java8-lambda.golo
@@ -3,5 +3,6 @@ module golotest.execution.Lambdas
 function sum_it = ->
   list[1, 2, 3, 4, 5]:
     stream():
+    filter(|n| -> n % 2 == 0):
     map(|n| -> n * 10):
     reduce(0, |acc, next| -> acc + next)


### PR DESCRIPTION
This PR fixes bug #273.

We had a problem when adapting a Golo closure to a Java8 lambda, when
the required functional interface returns a primitive type. This
appears for instance when using `Stream::filter`, since
`Predicate::test` returns a `boolean`.
Fixed by forcing the implemented signature in the `metafactory` to the required one.